### PR TITLE
Add dotfiles and code refactor

### DIFF
--- a/dotfiles/.gitconfig.sh
+++ b/dotfiles/.gitconfig.sh
@@ -1,0 +1,2 @@
+[core]
+        editor = vim

--- a/dotfiles/.vimrc
+++ b/dotfiles/.vimrc
@@ -1,0 +1,1 @@
+:set number

--- a/setup.sh
+++ b/setup.sh
@@ -2,8 +2,13 @@
 shopt -s dotglob
 
 cd dotfiles
-for f in *; 
+for file in *; 
 do
-	cp $f ~//
+	if [[ $file == *.sh ]]; then
+		filename=${file::-3}
+		cat $file >> ~/"${filename}"
+	else
+		cp $f ~//
+	fi
 done
 cd ..

--- a/setup.sh
+++ b/setup.sh
@@ -8,7 +8,7 @@ do
 		filename=${file::-3}
 		cat $file >> ~/"${filename}"
 	else
-		cp $f ~//
+		cp $file ~//
 	fi
 done
 cd ..


### PR DESCRIPTION


dotfiles include adding:

1. ```vimrc``` to get line number immediately when editing a file through 
2.  add ```gitconfig``` dotfile to make vim default editor for git (for a user not system-wide)

refactor setup.sh:
instead of overwriting some files which is bad practice, when a file in dotfiles/ ends with ```.sh``` it means that the configuration will be appended to the file rather than overwriting.
